### PR TITLE
Fix python3 support

### DIFF
--- a/grab/export/mysql_dumper.py
+++ b/grab/export/mysql_dumper.py
@@ -8,7 +8,7 @@ class MysqlCSVDumper(CSVDumper):
     Difference from CSVDumper:
     * default `quoting` value is QUOTE_MINIMAL
     * default `write_header` value is False
-    * None values are converted to r'\N'
+    * None values are converted to r'\\N'
     * \ symbols are converted to \\
     """
 

--- a/grab/util/log.py
+++ b/grab/util/log.py
@@ -17,7 +17,7 @@ def repr_value(val):
 
 
 def print_dict(dic):
-    print '[---'
+    print('[---')
     for key, val in sorted(dic.items(), key=lambda x: x[0]):
-        print key, ':', repr_value(val)
-    print '---]'
+        print(key, ':', repr_value(val))
+    print('---]')

--- a/grab/util/py2x_support.py
+++ b/grab/util/py2x_support.py
@@ -6,4 +6,4 @@
 
 # Support raise syntax in Python 2.x
 def reraise(tp, value, tb=None):
-    raise tp, value, tb
+    raise (tp, value, tb)


### PR DESCRIPTION
Python3 support was broken, because of several places where was used
python2 syntax, that is incompatible with the syntax of python3.