### PR TITLE
fixed find_refresh_url bug

### DIFF
--- a/grab/tools/html.py
+++ b/grab/tools/html.py
@@ -17,9 +17,9 @@ RE_REFRESH_TAG = re.compile(r'<meta[^>]+http-equiv\s*=\s*["\']*Refresh[^>]+', re
 # <meta http-equiv='REFRESH' content='0;url= http://www.bk55.ru/mc2/news/article/855'>
 RE_REFRESH_URL = re.compile(r'''
     content \s* = \s*
-    ["\']* \d+
+    ["\']* \s* \d+ \s*
     ;
-    (?: ; \s* url \s* = \s*)?
+    (?: \s* url \s* = \s*)?
     ["\']* ([^\'"> ]*)
 ''', re.I | re.X)
 

--- a/test/case/tools_html.py
+++ b/test/case/tools_html.py
@@ -2,13 +2,14 @@
 from unittest import TestCase
 from grab.tools.html import find_refresh_url
 
+
 class HtmlToolsTestCase(TestCase):
 
     def test_find_refresh_url(self):
         url = find_refresh_url("""
             <meta http-equiv="refresh" content="5">
         """)
-        self.assertEqual('', url)
+        self.assertEqual(None, url)
 
         url = find_refresh_url("""
             <meta http-equiv="refresh" content="5;URL='http://example.com/'">
@@ -22,5 +23,10 @@ class HtmlToolsTestCase(TestCase):
 
         url = find_refresh_url("""
             <meta http-equiv="refresh" content="5; url=http://example.com/">
+        """)
+        self.assertEqual('http://example.com/', url)
+
+        url = find_refresh_url("""
+            <meta http-equiv="refresh" content=" 0 ; url=http://example.com/">
         """)
         self.assertEqual('http://example.com/', url)


### PR DESCRIPTION
Не отрабатывал тест test.case.tools_html из-за того что была ошибка в регулярном выражении в функции grab.tools.html.find_refresh_url