### PR TITLE
cookie_domain fix

### DIFF
--- a/grab/transport/curl.py
+++ b/grab/transport/curl.py
@@ -377,7 +377,8 @@ class CurlTransport(object):
             http_only = cookie_domain.startswith('#httponly_')
             if http_only:
                 cookie_domain = cookie_domain.replace('#httponly_', '')
-            if not cookie_domain or host_nowww in cookie_domain:
+            if not cookie_domain or host_nowww in cookie_domain \
+                    or cookie_domain in host_nowww:
                 encoded = encode_cookies({cookie.name: cookie.value}, join=True,
                                          charset=grab.config['charset'])
                 cookie_string = b'Set-Cookie: ' + encoded


### PR DESCRIPTION
Для случая, когда в cookie_domain домен указывается частично, например .yandex.ru, а хост, например webmaster.yandex.ru, cookie устанавливаются неправильно.