### PR TITLE
Replaced the dictionary value access method with a get()

### DIFF
--- a/grab/cli.py
+++ b/grab/cli.py
@@ -41,7 +41,7 @@ def process_command_line():
     args, trash = parser.parse_known_args()
 
     config = build_root_config()
-    if config and config['GRAB_DJANGO_SETTINGS']:
+    if config and config.get('GRAB_DJANGO_SETTINGS'):
         os.environ['DJANGO_SETTINGS_MODULE'] = 'settings'
         # Turn off DEBUG to prevent memory leaks
         from django.conf import settings


### PR DESCRIPTION
Изменен способ получения значения из словаря по ключу на метод get() так, как при отсутствии значения в словаре этот метод вернет None, и не приведет к появлению ошибки KeyError.