### PR TITLE
added possibility to configure proxy auth data in Grab().proxylist fo…

### DIFF
--- a/test/spider_proxy.py
+++ b/test/spider_proxy.py
@@ -130,9 +130,10 @@ class TestSpider(BaseGrabTestCase):
                     'ports', int(grab.response.headers.get('Listen-Port', 0)))
 
         class CustomProxySource(BaseProxySource):
-            def load(self):
+            def load(self, userpwd):
                 return [
-                    Proxy(ADDRESS, TEST_SERVER_PORT, None, None, 'http'),
+                    Proxy(ADDRESS, TEST_SERVER_PORT,
+                          userpwd['login'], userpwd['password'], 'http'),
                 ]
 
 


### PR DESCRIPTION
смысл такой, когда загружается проксилист формата "адрес:порт", то, если установлен Grab().proxylist.userpwd, Proxy объект формируется с задаными параметрами авторизации, если в загружаемом списке указаны логин и пароль, то Proxy объект формируется с теми данными, что были в файле.