### PR TITLE
ZeroDivisionError, again

### DIFF
--- a/grab/stat.py
+++ b/grab/stat.py
@@ -62,7 +62,7 @@ class Stat(object):
     def get_speed_line(self, now):
         items = []
         for key in self.speed_keys:
-            if now == self.time:
+            if now - self.time == 0:
                 qps = 0
             else:
                 count_current = self.counters[key]


### PR DESCRIPTION
Снова начались ошибки деления на ноль. Не разбирался, но

    if now == self.time:

Не всегда гарантирует, что разница не будет равна 0. (1 != -1, но 1 - 1 == 0).

P.S. Мне лично не нравится, что разница в моем фиксе вычисляется дважды. Видимо лучше сохранить в переменную.