### PR TITLE
Update testing.rst to remove "extra" flag

### DIFF
--- a/docs/en/source/usage/testing.rst
+++ b/docs/en/source/usage/testing.rst
@@ -10,7 +10,7 @@ To run all tests run the command:
 
 .. code:: shell
 
-	./runtest.py --test-all --extra --backend-mongo --backend-mysql --backend-redis --backend-postgres
+	./runtest.py --test-all --backend-mongo --backend-mysql --backend-redis --backend-postgres
 
 
 .. _usage_testing_control:


### PR DESCRIPTION
When following the instructions, the `--extra` flag will cause the tests to fail immediately with the following output:

```
$   ./runtest.py --test-all --extra --backend-mongo --backend-mysql --backend-redis --backend-postgres
Usage: runtest.py [options]

runtest.py: error: no such option: --extra
```

I noticed that this was also removed from the tox.ini file, so I've removed it from the documentation accordingly. 

As an aside, is it worthwhile to mention that we expect mongo, mysql, redis, and postgres to be running with particular settings in order for the tests to pass? On my first run, I didn't think about it and the tests took ~10 minutes because they were trying to contact services that were not running or not running with the expected settings for the tests.
