### PR TITLE
Add in dependency for defusedxml library and swap out lxml's parse

### DIFF
--- a/grab/document.py
+++ b/grab/document.py
@@ -287,7 +287,8 @@ class DomTreeExtension(object):
 
     def _build_dom(self, content, mode):
         from lxml.html import HTMLParser
-        from lxml.etree import XMLParser, parse
+        from lxml.etree import XMLParser
+        from defusedxml.lxml import parse
 
         assert mode in ('html', 'xml')
         if mode == 'html':
@@ -302,7 +303,6 @@ class DomTreeExtension(object):
             dom = parse(BytesIO(content),
                         parser=THREAD_STORAGE.xml_parser)
             return dom.getroot()
-
 
     def build_html_tree(self):
         from lxml.etree import ParserError
@@ -873,7 +873,6 @@ class Document(TextExtension, RegexpExtension, PyqueryExtension,
             try:
                 codecs.lookup(charset)
             except LookupError:
-                logger.error('Unknown charset found: %s' % charset)
                 self.charset = 'utf-8'
             else:
                 self.charset = charset

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pycurl
 selection
 weblib
 six
+defusedxml>=0.4.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,8 @@ setup(
     author_email='lorien@lorien.name',
 
     packages=find_packages(exclude=['test', 'test.files']),
-    install_requires=['lxml', 'pycurl', 'selection', 'weblib>=0.1.10', 'six'],
+    install_requires=['lxml', 'pycurl', 'selection', 'weblib>=0.1.10', 'six',
+                      'defusedxml>=0.4.1'],
 
     license="MIT",
     keywords="pycurl multicurl curl network parsing grabbing scraping"


### PR DESCRIPTION
Hi! I'm running some security scans on popular Python projects with [Bandit](https://github.com/openstack/bandit) and I came across a few things in Grab. Here's one related to XML:

```
>> Issue: Using lxml.etree.parse to parse untrusted XML data is known to be vulnerable to XML attacks. Replace lxml.etree.parse with it's defusedxml equivalent function.
    Argument/s:
        Call(func=Name(id='BytesIO', ctx=Load()), args=[Name(id='content', ctx=Load())], keywords=[], starargs=None, kwargs=None)
   Severity: Medium   Confidence: High
   Location: grab/document.py:303
299             return dom.getroot()
300         else:
301             if not hasattr(THREAD_STORAGE, 'xml_parser'):
302                 THREAD_STORAGE.xml_parser = XMLParser()
303             dom = parse(BytesIO(content),
304                         parser=THREAD_STORAGE.xml_parser)
305             return dom.getroot()
```

Because we're parsing input that may or may not be what we expect, an attacker could put in a crafted set of input to cause problems with our machines. [defusedxml](https://pypi.python.org/pypi/defusedxml) was made to work with some of those problems. In this case, lxml's parse is susceptible to [quadratic expansion](https://pypi.python.org/pypi/defusedxml#quadratic-blowup-entity-expansion). I know introducing a new dependency is not to be taken lightly. If you'd prefer to replicate the code without including the dependency, it's here:

https://bitbucket.org/tiran/defusedxml/src/ac560aaf6f4a8c1e00b7961a11123d7580110056/defusedxml/lxml.py?at=default#lxml.py-127
