### PR TITLE
libcurl 7.56 и старше

### DIFF
--- a/grab/transport/curl.py
+++ b/grab/transport/curl.py
@@ -462,7 +462,7 @@ class CurlTransport(BaseTransport):
             cookie.path,
             'TRUE' if cookie.secure else 'FALSE',
             (str(cookie.expires) if cookie.expires
-             else 'Fri, 31 Dec 9999 23:59:59 GMT'),
+             else '0'),
             cookie.name,
             cookie.value,
         ]


### PR DESCRIPTION
В версии 7.52 работает, а в 7.56 уже такой формат даты не катит!
Ошибки не выдаёт, просто не выставляет кукисы через pycurl.COOKIELIST
Нужен Epoch timestamp, если я правильно понимаю.
https://curl.haxx.se/libcurl/c/CURLOPT_COOKIELIST.html

Fri, 31 Dec 9999 23:59:59 GMT = 253402300799 ;)