### PR TITLE
curl: use timestamp instead of string date for cookie expiration

### DIFF
--- a/grab/transport/curl.py
+++ b/grab/transport/curl.py
@@ -462,7 +462,7 @@ class CurlTransport(BaseTransport):
             cookie.path,
             'TRUE' if cookie.secure else 'FALSE',
             (str(cookie.expires) if cookie.expires
-             else 'Fri, 31 Dec 9999 23:59:59 GMT'),
+             else '9999999999'),
             cookie.name,
             cookie.value,
         ]


### PR DESCRIPTION
libcurl expects unix timestamp for cookie expiration column
since lbcurl v7.56.0 cookies with unexpected expiration format are rejected and not used
https://github.com/curl/curl/commit/ff50fe0348466cae1a9f9f759b362c03f7060c34#diff-000a13d4f44b585c3afbd0b469c82086R762